### PR TITLE
Adjust projectile behaviours

### DIFF
--- a/MoteurPhysique/src/Projectile.cpp
+++ b/MoteurPhysique/src/Projectile.cpp
@@ -9,14 +9,16 @@ Projectile::Projectile(ProjectileType T, const ProjectileConfig& config, const V
     particule = new Particule(
         position,
         config.vitesseInitiale,
-        Vector3D(0, (config.masse)*981.f, 0),
+        Vector3D(0, (config.masse)*981.f * config.gravityScale, 0),
         config.masse
         );
     type = T;
     couleur = config.couleur;
+    this->config = config;
+    particule->setDamping(config.damping);
     float dt0 = 1.0f / 60.0f; // ou ton dt initial
     particule->setOldPosition(position - config.vitesseInitiale.scalar(dt0));
-    
+
 }
 
 void Projectile::update(float deltaTime)
@@ -24,11 +26,19 @@ void Projectile::update(float deltaTime)
     float invM = particule->getInverseMasse();
     if (invM > 0.0f) {
         float m = 1.0f / invM;
-        particule->setForce(Vector3D(0.f, 981.f * m, 0.f));
+        Vector3D totalForce(0.f, 981.f * config.gravityScale * m, 0.f);
+
+        if (config.dragCoefficient > 0.0f) {
+            Vector3D velocity = particule->getVx();
+            Vector3D drag = velocity.scalar(-config.dragCoefficient);
+            totalForce = totalForce + drag;
+        }
+
+        particule->setForce(totalForce);
     } else {
         particule->setForce(Vector3D(0.f, 0.f, 0.f));
     }
-    
+
     particule->integrerVerlet(deltaTime);
     Vector3D pos = particule->getPos();
     trajectoire.emplace_back(pos.x, pos.y, pos.z);

--- a/MoteurPhysique/src/Projectile.h
+++ b/MoteurPhysique/src/Projectile.h
@@ -11,6 +11,9 @@ struct ProjectileConfig {
     float masse;
     Vector3D vitesseInitiale;
     ofColor couleur;
+    float gravityScale;
+    float dragCoefficient;
+    float damping;
 };
 
 class Projectile
@@ -20,7 +23,8 @@ public:
     ProjectileType type;
     ofColor couleur;
     std::vector<ofVec3f> trajectoire;
-    
+    ProjectileConfig config;
+
     Projectile(ProjectileType T, const ProjectileConfig& config, const Vector3D& position);
 
     void update(float deltaTime);

--- a/MoteurPhysique/src/ofApp.cpp
+++ b/MoteurPhysique/src/ofApp.cpp
@@ -3,25 +3,37 @@
 
 //--------------------------------------------------------------
 void ofApp::setup(){
-	projectileConfigs[ProjectileType::Balle] =
-	{ .masse = 0.02f,  // 20 g (balle d'airsoft)
-	  .vitesseInitiale = {500, -866, 0}, 
-	  .couleur = ofColor::blue };
+        projectileConfigs[ProjectileType::Balle] =
+        { .masse = 0.02f,  // 20 g (balle d'airsoft)
+          .vitesseInitiale = {900.f, -120.f, 0.f}, // trajectoire quasi rectiligne
+          .couleur = ofColor::blue,
+          .gravityScale = 1.0f,
+          .dragCoefficient = 0.45f,
+          .damping = 0.985f };
 
-	projectileConfigs[ProjectileType::Boulet] =
-	{ .masse = 5.0f,   // 5 kg
-	  .vitesseInitiale = {400, -692, 0}, // lourd, donc plus lent
-	  .couleur = ofColor::gray };
+        projectileConfigs[ProjectileType::Boulet] =
+        { .masse = 5.0f,   // 5 kg
+          .vitesseInitiale = {550.f, -900.f, 0.f}, // cloche prononcée
+          .couleur = ofColor::gray,
+          .gravityScale = 1.15f,
+          .dragCoefficient = 0.05f,
+          .damping = 0.995f };
 
-	projectileConfigs[ProjectileType::Laser] =
-	{ .masse = 0.0001f, // quasi nul
-	  .vitesseInitiale = {3000, -5186, 0},  // constant, pas affecté visuellement par gravité
-	  .couleur = ofColor::green };
+        projectileConfigs[ProjectileType::Laser] =
+        { .masse = 0.01f,
+          .vitesseInitiale = {2500.f, 0.f, 0.f},  // trajectoire parfaitement droite
+          .couleur = ofColor::green,
+          .gravityScale = 0.0f,
+          .dragCoefficient = 0.0f,
+          .damping = 1.0f };
 
-	projectileConfigs[ProjectileType::BouleDeFeu] =
-	{ .masse = 1.0f,   // 1 kg (masse symbolique)
-	  .vitesseInitiale = {200, -346, 0}, // lent mais chute plus vite
-	  .couleur = ofColor::red };
+        projectileConfigs[ProjectileType::BouleDeFeu] =
+        { .masse = 1.0f,   // 1 kg (masse symbolique)
+          .vitesseInitiale = {260.f, -220.f, 0.f}, // lente et portée courte
+          .couleur = ofColor::red,
+          .gravityScale = 0.8f,
+          .dragCoefficient = 0.25f,
+          .damping = 0.975f };
 
 	lastTime = ofGetElapsedTimeMillis();
 }

--- a/MoteurPhysique/src/particule.cpp
+++ b/MoteurPhysique/src/particule.cpp
@@ -5,11 +5,12 @@
 
 Particule::Particule(Vector3D pos,
                      Vector3D vel,
-                     Vector3D force, 
+                     Vector3D force,
                      float masse)
-    : _pos(pos), 
-      _vel(vel), 
-      _force(force) 
+    : _pos(pos),
+      _vel(vel),
+      _force(force),
+      _damping(0.99f)
 {
     _oldPos = _pos - _vel.scalar(0.016f); // 60fps
     setMasse(masse);
@@ -75,6 +76,10 @@ void Particule::setMasse(float masse) {
     }
 }
 
+void Particule::setDamping(float damping) {
+    _damping = damping;
+}
+
 /*void Particule::integrerVerlet(float dt) {
     if (_inverseMasse <= 0.0f) return; 
 
@@ -90,11 +95,10 @@ void Particule::setMasse(float masse) {
 void Particule::integrerVerlet(float dt) {
     if (_inverseMasse <= 0.0f) return;
 
-    const float damping = 0.99f; // proche de 1.0 pour pas tuer la dynamique
     Vector3D acc = _force.scalar(_inverseMasse);
 
     Vector3D temp = _pos;
-    _pos = _pos + (_pos - _oldPos).scalar(damping) + acc.scalar(dt * dt);
+    _pos = _pos + (_pos - _oldPos).scalar(_damping) + acc.scalar(dt * dt);
     _oldPos = temp;
 
     _vel = (_pos - _oldPos).scalar(1.f/dt); // vitesse dérivée des positions

--- a/MoteurPhysique/src/particule.h
+++ b/MoteurPhysique/src/particule.h
@@ -15,6 +15,8 @@ class Particule {
 
     float _inverseMasse;
 
+    float _damping;
+
 public:
     Particule(Vector3D pos,
               Vector3D vel,
@@ -44,6 +46,8 @@ public:
     void setForce(Vector3D force);
 
     void setMasse(float masse);
+
+    void setDamping(float damping);
 
     void integrerVerlet(float dt);
 };


### PR DESCRIPTION
## Summary
- extend projectile configuration with gravity, drag and damping parameters and use them during Verlet integration
- tune each projectile preset so the bullet, cannonball, laser and fireball follow distinct trajectories

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d0cd3930b88320ac2bc34de671eb5b