### PR TITLE
Integrate collision detection into phase 3 simulation

### DIFF
--- a/MoteurPhysique/src/World/RigidBodyBox.h
+++ b/MoteurPhysique/src/World/RigidBodyBox.h
@@ -4,6 +4,8 @@
 #include "../CorpsRigide/CorpsRigide.h"
 #include "ofColor.h"
 
+#include <memory>
+
 struct RigidBodyBox
 {
         CorpsRigide body;
@@ -13,6 +15,7 @@ struct RigidBodyBox
         float boundingRadius = 1.f;
         bool reachedGoal = false;
         bool outOfBounds = false;
-		Primitive* primitive = new Box(halfExtents);
+
+        std::unique_ptr<Box> primitive;
 };
 

--- a/MoteurPhysique/src/World/World.cpp
+++ b/MoteurPhysique/src/World/World.cpp
@@ -21,10 +21,9 @@ Vector3D normalizedAxis(float x, float y, float z)
 
 bool computeBoxBoxContact(const AABB& aabbA,
                           const AABB& aabbB,
-                          const Vector3D& centerA,
-                          const Vector3D& centerB,
                           Vector3D& outNormal,
-                          float& outPenetration)
+                          float& outPenetration,
+                          Vector3D& outContactPoint)
 {
         float overlapX = std::min(aabbA.max.x, aabbB.max.x) - std::max(aabbA.min.x, aabbB.min.x);
         float overlapY = std::min(aabbA.max.y, aabbB.max.y) - std::max(aabbA.min.y, aabbB.min.y);
@@ -33,6 +32,9 @@ bool computeBoxBoxContact(const AABB& aabbA,
         if (overlapX <= 0.f || overlapY <= 0.f || overlapZ <= 0.f) {
                 return false;
         }
+
+        Vector3D centerA = (aabbA.min + aabbA.max).scalar(0.5f);
+        Vector3D centerB = (aabbB.min + aabbB.max).scalar(0.5f);
 
         outPenetration = overlapX;
         outNormal = Vector3D((centerB.x >= centerA.x) ? 1.f : -1.f, 0.f, 0.f);
@@ -45,6 +47,8 @@ bool computeBoxBoxContact(const AABB& aabbA,
                 outPenetration = overlapZ;
                 outNormal = Vector3D(0.f, 0.f, (centerB.z >= centerA.z) ? 1.f : -1.f);
         }
+
+        outContactPoint = (centerA + centerB).scalar(0.5f);
 
         return true;
 }
@@ -350,12 +354,11 @@ void World::narrowPhaseDetection(const std::vector<std::pair<Primitive *, Primit
                 }
 
                 Vector3D normal;
+                Vector3D contactPoint;
                 float penetration = 0.f;
                 if (computeBoxBoxContact(bodyA->worldAABB, bodyB->worldAABB,
-                                         bodyA->getPosition(), bodyB->getPosition(),
-                                         normal, penetration))
+                                         normal, penetration, contactPoint))
                 {
-                        Vector3D contactPoint = (bodyA->getPosition() + bodyB->getPosition()).scalar(0.5f);
                         collisionSystem->add(box1, box2, contactPoint, normal, penetration, 0.35f, collision_type::Contact);
                 }
         }

--- a/MoteurPhysique/src/World/World.cpp
+++ b/MoteurPhysique/src/World/World.cpp
@@ -23,7 +23,8 @@ Vector3D normalizedAxis(float x, float y, float z)
 
 World::World()
 {
-	collisionSystem = std::make_unique<SystemeCollisionDetection>();
+        collisionSystem = std::make_unique<SystemeCollisionDetection>();
+        m_worldBounds = AABB(Vector3D(-500.f, -500.f, -500.f), Vector3D(500.f, 500.f, 500.f));
 }
 
 World::~World()
@@ -116,6 +117,9 @@ RigidBodyBox World::createRigidBodyBox(const Vector3D& position,
     box.body.setVelociteAngulaire(initialAngularVelocity);
     box.body.clearAccumulators();
 
+    box.primitive = std::make_unique<Box>(halfExtents);
+    box.primitive->corpsRigide = &box.body;
+
     return box;
 }
 
@@ -159,37 +163,117 @@ std::vector<RigidBodyBox> World::createRigidBodyGame(int boxCount,
     return boxes;
 }
 
+void World::setWorldBounds(const AABB& bounds)
+{
+        m_worldBounds = bounds;
+}
+
+void World::clearRigidBodies()
+{
+        m_rigidBodies.clear();
+}
+
+void World::registerRigidBody(RigidBodyBox& body)
+{
+        if (body.reachedGoal || body.outOfBounds) {
+                return;
+        }
+
+        if (!body.primitive) {
+                body.primitive = std::make_unique<Box>(body.halfExtents);
+        }
+
+        body.primitive->corpsRigide = &body.body;
+        m_rigidBodies.push_back(&body);
+}
+
+void World::registerRigidBodies(std::vector<RigidBodyBox>& bodies)
+{
+        clearRigidBodies();
+        for (auto& body : bodies) {
+                registerRigidBody(body);
+        }
+}
+
+void World::addStaticPlane(const Vector3D& normal, float offset)
+{
+        auto planeBody = std::make_unique<CorpsRigide>();
+        planeBody->setInverseMasse(0.f);
+        planeBody->setOrientation(Quaternion());
+        planeBody->setPosition(Vector3D());
+
+        auto plane = std::make_unique<Plane>();
+        plane->normal = normal;
+        plane->PlaneOffset = offset;
+        plane->corpsRigide = planeBody.get();
+
+        m_staticPlanes.push_back(std::move(plane));
+        m_staticBodies.push_back(std::move(planeBody));
+}
+
+void World::clearStaticPlanes()
+{
+        m_staticPlanes.clear();
+        m_staticBodies.clear();
+}
+
+void World::simulateRigidBodies(float deltaTime)
+{
+        if (deltaTime <= 0.f) {
+                return;
+        }
+
+        for (auto& bodybox : m_rigidBodies) {
+                applyRigidBodyForces(bodybox->body, deltaTime);
+                bodybox->body.integrer(deltaTime);
+        }
+
+        broadPhaseDetection();
+
+        if (collisionSystem) {
+                collisionSystem->resolveAll();
+        }
+
+        for (auto& bodybox : m_rigidBodies) {
+                bodybox->body.clearAccumulators();
+        }
+}
+
 void World::broadPhaseDetection() {
-	// Construire l'octree
-	m_octree = std::make_unique<Octree>(m_worldBounds);
+        // Construire l'octree
+        m_octree = std::make_unique<Octree>(m_worldBounds);
 
-	// MAJ AABB et insert dans le octree
-	for (auto & body_box : m_rigidBodies) {
-		body_box->body.calculateWorldAABB(*body_box->primitive);
-		m_octree->insert(body_box->primitive, body_box->body.worldAABB);
-	}
+        std::vector<std::pair<Primitive*, AABB>> collidables;
 
-	// Genere les pairs potentielles
-	std::vector<std::pair<Primitive*, Primitive*>> potentialCollisions;
+        // MAJ AABB et insert dans le octree
+        for (auto & body_box : m_rigidBodies) {
+                body_box->body.calculateWorldAABB(*body_box->primitive);
+                m_octree->insert(body_box->primitive.get(), body_box->body.worldAABB);
+                collidables.emplace_back(body_box->primitive.get(), body_box->body.worldAABB);
+        }
 
-	for (auto& body_boxA : m_rigidBodies) {
-		Primitive* primitiveA = body_boxA->primitive;
+        for (auto& plane : m_staticPlanes) {
+                // Les plans statiques utilisent les limites du monde comme boîte englobante.
+                m_octree->insert(plane.get(), m_worldBounds);
+                collidables.emplace_back(plane.get(), m_worldBounds);
+        }
 
-		std::vector<Primitive*> condidates = m_octree->request(body_boxA->body.worldAABB);
+        // Genere les pairs potentielles
+        std::vector<std::pair<Primitive*, Primitive*>> potentialCollisions;
 
-		for (Primitive* primitiveB : condidates) {
-			if (primitiveA < primitiveB) {
-				potentialCollisions.push_back(std::make_pair(primitiveA, primitiveB));
-			}
-		}
-	}
+        for (const auto& entry : collidables) {
+                Primitive* primitiveA = entry.first;
+                std::vector<Primitive*> candidates = m_octree->request(entry.second);
 
+                for (Primitive* primitiveB : candidates) {
+                        if (primitiveA < primitiveB) {
+                                potentialCollisions.push_back(std::make_pair(primitiveA, primitiveB));
+                        }
+                }
+        }
 
-	// À ce stade, normalement `potentialCollisions` contient toutes les paires à tester en phase restreinte.
-	narrowPhaseDetection(potentialCollisions);
-	
-	std::cout << "Collisions potentielles cette frame: " << potentialCollisions.size() << std::endl;
-
+        // À ce stade, normalement `potentialCollisions` contient toutes les paires à tester en phase restreinte.
+        narrowPhaseDetection(potentialCollisions);
 }
 
 void World::narrowPhaseDetection(const std::vector<std::pair<Primitive *, Primitive *>> & potentialCollisions)

--- a/MoteurPhysique/src/World/World.cpp
+++ b/MoteurPhysique/src/World/World.cpp
@@ -19,6 +19,36 @@ Vector3D normalizedAxis(float x, float y, float z)
     return axis.scalar(1.f / norm);
 }
 
+bool computeBoxBoxContact(const AABB& aabbA,
+                          const AABB& aabbB,
+                          const Vector3D& centerA,
+                          const Vector3D& centerB,
+                          Vector3D& outNormal,
+                          float& outPenetration)
+{
+        float overlapX = std::min(aabbA.max.x, aabbB.max.x) - std::max(aabbA.min.x, aabbB.min.x);
+        float overlapY = std::min(aabbA.max.y, aabbB.max.y) - std::max(aabbA.min.y, aabbB.min.y);
+        float overlapZ = std::min(aabbA.max.z, aabbB.max.z) - std::max(aabbA.min.z, aabbB.min.z);
+
+        if (overlapX <= 0.f || overlapY <= 0.f || overlapZ <= 0.f) {
+                return false;
+        }
+
+        outPenetration = overlapX;
+        outNormal = Vector3D((centerB.x >= centerA.x) ? 1.f : -1.f, 0.f, 0.f);
+
+        if (overlapY < outPenetration) {
+                outPenetration = overlapY;
+                outNormal = Vector3D(0.f, (centerB.y >= centerA.y) ? 1.f : -1.f, 0.f);
+        }
+        if (overlapZ < outPenetration) {
+                outPenetration = overlapZ;
+                outNormal = Vector3D(0.f, 0.f, (centerB.z >= centerA.z) ? 1.f : -1.f);
+        }
+
+        return true;
+}
+
 }
 
 World::World()
@@ -309,6 +339,25 @@ void World::narrowPhaseDetection(const std::vector<std::pair<Primitive *, Primit
         {
             // On inverse les arguments car DetectBoxPlane attend (Box, Plane)
             collisionSystem->DetectBoxPlane(box2, plane1);
+        }
+        else if (box1 && box2)
+        {
+                CorpsRigide* bodyA = box1->corpsRigide;
+                CorpsRigide* bodyB = box2->corpsRigide;
+
+                if (!bodyA || !bodyB) {
+                        continue;
+                }
+
+                Vector3D normal;
+                float penetration = 0.f;
+                if (computeBoxBoxContact(bodyA->worldAABB, bodyB->worldAABB,
+                                         bodyA->getPosition(), bodyB->getPosition(),
+                                         normal, penetration))
+                {
+                        Vector3D contactPoint = (bodyA->getPosition() + bodyB->getPosition()).scalar(0.5f);
+                        collisionSystem->add(box1, box2, contactPoint, normal, penetration, 0.35f, collision_type::Contact);
+                }
         }
     }
 }

--- a/MoteurPhysique/src/World/World.h
+++ b/MoteurPhysique/src/World/World.h
@@ -3,6 +3,7 @@
 #include "Octree.h"
 
 #include <vector>
+#include <memory>
 #include "../MathStruct/3DVector.h"
 #include "../particule.h"
 #include "../ForceGenerator/ParticuleForceRegistry.h"
@@ -68,6 +69,41 @@ public:
                                                   float boundsX,
                                                   float boundsZ) const;
 
+        /**
+         * @brief Met à jour les limites du monde pour l'octree et les collisions.
+         */
+        void setWorldBounds(const AABB& bounds);
+
+        /**
+         * @brief Réinitialise la liste des corps rigides enregistrés pour la simulation.
+         */
+        void clearRigidBodies();
+
+        /**
+         * @brief Inscrit un corps rigide pour la simulation et prépare sa primitive.
+         */
+        void registerRigidBody(RigidBodyBox& body);
+
+        /**
+         * @brief Synchronise tous les corps rigides actifs avec le système de collision.
+         */
+        void registerRigidBodies(std::vector<RigidBodyBox>& bodies);
+
+        /**
+         * @brief Ajoute un plan statique qui participera aux collisions (sol, murs, etc.).
+         */
+        void addStaticPlane(const Vector3D& normal, float offset);
+
+        /**
+         * @brief Supprime tous les plans statiques précédemment enregistrés.
+         */
+        void clearStaticPlanes();
+
+        /**
+         * @brief Applique les forces, intègre et résout les collisions pour les corps rigides.
+         */
+        void simulateRigidBodies(float deltaTime);
+
 private:
     std::vector<Particule*> m_particules;
 
@@ -75,17 +111,19 @@ private:
     RigidBodyForceRegistry m_rigidBodyForceRegistry;
     SystemCollisionDetection m_collisionDetector;
 
-	// Systeme de collision
-	std::unique_ptr<SystemeCollisionDetection> collisionSystem;
-	
-	// Le monde possède les corps rigides
-	std::vector<RigidBodyBox*> m_rigidBodies;
+        // Systeme de collision
+        std::unique_ptr<SystemeCollisionDetection> collisionSystem;
 
-	// L'Octree, reconstruit à chaque frame
-	std::unique_ptr<Octree> m_octree;
+        // Le monde possède les corps rigides
+        std::vector<RigidBodyBox*> m_rigidBodies;
+        std::vector<std::unique_ptr<Plane>> m_staticPlanes;
+        std::vector<std::unique_ptr<CorpsRigide>> m_staticBodies;
 
-	// Les limites de l'espace de simulation
-	AABB m_worldBounds;
+        // L'Octree, reconstruit à chaque frame
+        std::unique_ptr<Octree> m_octree;
+
+        // Les limites de l'espace de simulation
+        AABB m_worldBounds;
 
 	// Méthodes privées pour la détection de collision
 	void broadPhaseDetection();

--- a/MoteurPhysique/src/ofApp.cpp
+++ b/MoteurPhysique/src/ofApp.cpp
@@ -7,6 +7,7 @@
 #include "ForceGenerator/ForceGravity.h"
 #include "Tests/3DVectorTest.h"
 #include "glm/vec3.hpp"
+#include "MathStruct/AABB.h"
 
 #include <algorithm>
 #include <cmath>
@@ -501,12 +502,16 @@ void ofApp::clearBlobMovementKeys()
 //--------------------------------------------------------------
 void ofApp::setupRigidBodyGame()
 {
-	
+
         rigidBodyCamera.setNearClip(0.1f);
         rigidBodyCamera.setFarClip(4000.f);
         rigidBodyCamera.setPosition(0.f, 360.f, 620.f);
         rigidBodyCamera.lookAt(glm::vec3(0.f, rigidBodyFloorY + 80.f, 0.f));
         rigidBodyCamera.setAutoDistance(false);
+
+        physicsWorld.setWorldBounds(
+                AABB(Vector3D(-rigidBodyBoundsX - 40.f, rigidBodyFloorY - 80.f, -rigidBodyBoundsZ - 40.f),
+                     Vector3D(rigidBodyBoundsX + 40.f, dropperSpawnHeight + 140.f, rigidBodyBoundsZ + 40.f)));
 
         performRigidBodyGameReset();
 }
@@ -535,6 +540,13 @@ void ofApp::performRigidBodyGameReset()
         clearRigidBodyMovementKeys();
 
         goalCenter.y = rigidBodyFloorY;
+
+        physicsWorld.clearStaticPlanes();
+        physicsWorld.addStaticPlane(Vector3D(0.f, 1.f, 0.f), rigidBodyFloorY);
+        physicsWorld.addStaticPlane(Vector3D(1.f, 0.f, 0.f), -rigidBodyBoundsX);
+        physicsWorld.addStaticPlane(Vector3D(-1.f, 0.f, 0.f), -rigidBodyBoundsX);
+        physicsWorld.addStaticPlane(Vector3D(0.f, 0.f, 1.f), -rigidBodyBoundsZ);
+        physicsWorld.addStaticPlane(Vector3D(0.f, 0.f, -1.f), -rigidBodyBoundsZ);
 
         auto initialBoxes = physicsWorld.createRigidBodyGame(30, dropperSpawnHeight, rigidBodyBoundsX, rigidBodyBoundsZ);
         for (auto& box : initialBoxes) {
@@ -600,16 +612,14 @@ void ofApp::updateRigidBodyGame(float dt)
         dropperX = ofClamp(dropperX + moveX, -rigidBodyBoundsX + 20.f, rigidBodyBoundsX - 20.f);
         dropperZ = ofClamp(dropperZ + moveZ, -rigidBodyBoundsZ + 20.f, rigidBodyBoundsZ - 20.f);
 
+        physicsWorld.registerRigidBodies(rigidBodies);
+        physicsWorld.simulateRigidBodies(dt);
+
         for (auto& box : rigidBodies) {
                 if (box.reachedGoal || box.outOfBounds) {
                         continue;
                 }
 
-                physicsWorld.applyRigidBodyForces(box.body, dt);
-
-                box.body.integrer(dt);
-
-                applyRigidBodyBounds(box);
                 handleRigidBodyGoal(box);
 
                 Vector3D position = box.body.getPosition();
@@ -621,62 +631,6 @@ void ofApp::updateRigidBodyGame(float dt)
 }
 
 //--------------------------------------------------------------
-void ofApp::applyRigidBodyBounds(RigidBodyBox& box)
-{
-        Vector3D position = box.body.getPosition();
-        Vector3D velocity = box.body.getVelocite();
-        Vector3D angular = box.body.getVelociteAngulaire();
-
-        float radius = box.boundingRadius;
-        bool touchedFloor = false;
-
-        if (position.y - radius < rigidBodyFloorY) {
-                position.y = rigidBodyFloorY + radius;
-                if (velocity.y < 0.f) {
-                        velocity.y = -velocity.y * rigidBodyBounce;
-                }
-                touchedFloor = true;
-        }
-
-        if (position.x - radius < -rigidBodyBoundsX) {
-                position.x = -rigidBodyBoundsX + radius;
-                if (velocity.x < 0.f) {
-                        velocity.x = -velocity.x * rigidBodyBounce;
-                }
-        } else if (position.x + radius > rigidBodyBoundsX) {
-                position.x = rigidBodyBoundsX - radius;
-                if (velocity.x > 0.f) {
-                        velocity.x = -velocity.x * rigidBodyBounce;
-                }
-        }
-
-        if (position.z - radius < -rigidBodyBoundsZ) {
-                position.z = -rigidBodyBoundsZ + radius;
-                if (velocity.z < 0.f) {
-                        velocity.z = -velocity.z * rigidBodyBounce;
-                }
-        } else if (position.z + radius > rigidBodyBoundsZ) {
-                position.z = rigidBodyBoundsZ - radius;
-                if (velocity.z > 0.f) {
-                        velocity.z = -velocity.z * rigidBodyBounce;
-                }
-        }
-
-        if (touchedFloor) {
-                velocity.x *= rigidBodyFloorFriction;
-                velocity.z *= rigidBodyFloorFriction;
-                angular = angular.scalar(rigidBodyFloorFriction);
-
-                if (std::abs(velocity.x) < 1e-2f) velocity.x = 0.f;
-                if (std::abs(velocity.y) < 1e-2f) velocity.y = 0.f;
-                if (std::abs(velocity.z) < 1e-2f) velocity.z = 0.f;
-        }
-
-        box.body.setPosition(position);
-        box.body.setVelocite(velocity);
-        box.body.setVelociteAngulaire(angular);
-}
-
 //--------------------------------------------------------------
 void ofApp::handleRigidBodyGoal(RigidBodyBox& box)
 {

--- a/MoteurPhysique/src/ofApp.h
+++ b/MoteurPhysique/src/ofApp.h
@@ -74,8 +74,6 @@ class ofApp : public ofBaseApp{
                 void spawnRigidBodyFromDropper();
                 /// Replace la scène du jeu dans son état initial.
                 void resetRigidBodyGame();
-                /// Applique les contraintes de l'aire de jeu au corps spécifié.
-                void applyRigidBodyBounds(RigidBodyBox& box);
                 /// Met à jour l'état de la zone de but pour le corps donné.
                 void handleRigidBodyGoal(RigidBodyBox& box);
                 /// Suit les entrées clavier propres au distributeur de la phase 3.


### PR DESCRIPTION
## Summary
- register phase 3 rigid bodies with the world collision system and simulate collisions each frame
- add static boundary planes and world bounds so collision detection can handle the playfield
- clean up rigid body primitive ownership to keep responsibilities in the world

## Testing
- Not run (not available in this environment)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6934648c14c88320b13a72d60fc1fd9a)