### PR TITLE
Add octree collision detection for rigid box game

### DIFF
--- a/MoteurPhysique/src/MathStruct/Octree.cpp
+++ b/MoteurPhysique/src/MathStruct/Octree.cpp
@@ -155,6 +155,23 @@ std::vector<Primitive*> Octree::request(const AABB& otherBounds)
     return FindObjects;
 }
 
+void Octree::gatherNodes(std::vector<AABB>& nodes) const
+{
+    nodes.push_back(Area);
+    if (!bHasBeenSubdivide)
+    {
+        return;
+    }
+
+    for (const auto& child : children)
+    {
+        if (child)
+        {
+            child->gatherNodes(nodes);
+        }
+    }
+}
+
 bool Octree::containsEntiraly(const AABB& other) const
 {
     return Area.contains(other);

--- a/MoteurPhysique/src/MathStruct/Octree.h
+++ b/MoteurPhysique/src/MathStruct/Octree.h
@@ -14,6 +14,8 @@ public:
 
     std::vector<Primitive*> request(const AABB& otherBounds);
 
+    void gatherNodes(std::vector<AABB>& nodes) const;
+
     bool containsEntiraly(const AABB& other) const;
 private:
     // Position du sommet AABB min(minx, miny, minz) et max(maxx, maxy, maxz)
@@ -24,7 +26,7 @@ private:
     std::vector<Primitive*> Objets;
 
 	// représentation 3d
-	std::array<std::unique_ptr<Octree>, 8> children;
+    std::array<std::unique_ptr<Octree>, 8> children;
 
     bool bHasBeenSubdivide = false;
 };

--- a/MoteurPhysique/src/World/RigidBodyBox.h
+++ b/MoteurPhysique/src/World/RigidBodyBox.h
@@ -3,6 +3,7 @@
 #include "Box.h"
 #include "../CorpsRigide/CorpsRigide.h"
 #include "ofColor.h"
+#include <memory>
 
 struct RigidBodyBox
 {
@@ -13,6 +14,6 @@ struct RigidBodyBox
         float boundingRadius = 1.f;
         bool reachedGoal = false;
         bool outOfBounds = false;
-		Primitive* primitive = new Box(halfExtents);
+        std::unique_ptr<Box> primitive;
 };
 

--- a/MoteurPhysique/src/World/World.cpp
+++ b/MoteurPhysique/src/World/World.cpp
@@ -1,6 +1,9 @@
 #include "World.h"
 
 #include <algorithm>
+#include <cmath>
+#include <set>
+#include <unordered_map>
 
 #include "ofMath.h"
 #include "ofMathConstants.h"
@@ -116,6 +119,9 @@ RigidBodyBox World::createRigidBodyBox(const Vector3D& position,
     box.body.setVelociteAngulaire(initialAngularVelocity);
     box.body.clearAccumulators();
 
+    box.primitive = std::make_unique<Box>(halfExtents);
+    box.primitive->corpsRigide = &box.body;
+
     return box;
 }
 
@@ -160,48 +166,74 @@ std::vector<RigidBodyBox> World::createRigidBodyGame(int boxCount,
 }
 
 void World::broadPhaseDetection() {
-	// Construire l'octree
-	m_octree = std::make_unique<Octree>(m_worldBounds);
+        if (!collisionSystem)
+        {
+                return;
+        }
 
-	// MAJ AABB et insert dans le octree
-	for (auto & body_box : m_rigidBodies) {
-		body_box->body.calculateWorldAABB(*body_box->primitive);
-		m_octree->insert(body_box->primitive, body_box->body.worldAABB);
-	}
+        // Construire l'octree à partir des limites actuelles
+        m_octree = std::make_unique<Octree>(m_worldBounds);
+        m_octreeDebugNodes.clear();
 
-	// Genere les pairs potentielles
-	std::vector<std::pair<Primitive*, Primitive*>> potentialCollisions;
+        std::unordered_map<Primitive*, AABB> sphereBounds;
 
-	for (auto& body_boxA : m_rigidBodies) {
-		Primitive* primitiveA = body_boxA->primitive;
+        for (auto & body_box : m_rigidBodies) {
+                if (!body_box->primitive)
+                {
+                        continue;
+                }
 
-		std::vector<Primitive*> condidates = m_octree->request(body_boxA->body.worldAABB);
+                body_box->body.calculateWorldAABB(*body_box->primitive);
 
-		for (Primitive* primitiveB : condidates) {
-			if (primitiveA < primitiveB) {
-				potentialCollisions.push_back(std::make_pair(primitiveA, primitiveB));
-			}
-		}
-	}
+                // Volume englobant sphérique pour la broad phase
+                Vector3D center = body_box->body.getPosition();
+                float radius = body_box->boundingRadius;
+                Vector3D min = center - Vector3D(radius, radius, radius);
+                Vector3D max = center + Vector3D(radius, radius, radius);
+                AABB bound(min, max);
 
+                sphereBounds[body_box->primitive.get()] = bound;
+                m_octree->insert(body_box->primitive.get(), bound);
+        }
 
-	// À ce stade, normalement `potentialCollisions` contient toutes les paires à tester en phase restreinte.
-	narrowPhaseDetection(potentialCollisions);
-	
-	std::cout << "Collisions potentielles cette frame: " << potentialCollisions.size() << std::endl;
+        // Conserve les noeuds pour l'affichage debug
+        if (m_octree)
+        {
+                m_octree->gatherNodes(m_octreeDebugNodes);
+        }
 
+        // Génère les paires potentielles
+        std::vector<std::pair<Primitive*, Primitive*>> potentialCollisions;
+
+        for (auto& body_boxA : m_rigidBodies) {
+                Primitive* primitiveA = body_boxA->primitive.get();
+                if (!primitiveA)
+                {
+                        continue;
+                }
+
+                std::vector<Primitive*> condidates = m_octree->request(sphereBounds[primitiveA]);
+
+                for (Primitive* primitiveB : condidates) {
+                        if (primitiveA < primitiveB) {
+                                potentialCollisions.push_back(std::make_pair(primitiveA, primitiveB));
+                        }
+                }
+        }
+
+        // À ce stade, normalement `potentialCollisions` contient toutes les paires à tester en phase restreinte.
+        narrowPhaseDetection(potentialCollisions);
 }
 
 void World::narrowPhaseDetection(const std::vector<std::pair<Primitive *, Primitive *>> & potentialCollisions)
 {
-    // 1. On vide les collisions de la frame précédente
-    if (collisionSystem) {
-        collisionSystem->clear();
-    } else {
+    if (!collisionSystem)
+    {
         return;
     }
 
-    // 2. On parcourt toutes les paires renvoyées par la Broad Phase
+    collisionSystem->clear();
+
     for (const auto& pair : potentialCollisions)
     {
         Primitive* p1 = pair.first;
@@ -209,23 +241,103 @@ void World::narrowPhaseDetection(const std::vector<std::pair<Primitive *, Primit
 
         if (!p1 || !p2) continue;
 
-        // 3. Identification des types (RTTI)
-        // On essaie de caster p1 et p2 en Box ou Plane
         Box* box1 = dynamic_cast<Box*>(p1);
         Box* box2 = dynamic_cast<Box*>(p2);
         Plane* plane1 = dynamic_cast<Plane*>(p1);
         Plane* plane2 = dynamic_cast<Plane*>(p2);
 
-        // --- Cas : Boîte vs Plan ---
-        if (box1 && plane2)
+        if (box1 && box2)
+        {
+            detectSphereSphere(box1, box2);
+        }
+        else if (box1 && plane2)
         {
             collisionSystem->DetectBoxPlane(box1, plane2);
         }
         else if (plane1 && box2)
         {
-            // On inverse les arguments car DetectBoxPlane attend (Box, Plane)
             collisionSystem->DetectBoxPlane(box2, plane1);
         }
+    }
+}
+
+void World::detectSphereSphere(Box* a, Box* b)
+{
+    if (!collisionSystem || !a || !b || !a->corpsRigide || !b->corpsRigide)
+    {
+        return;
+    }
+
+    Vector3D posA = a->corpsRigide->getPosition();
+    Vector3D posB = b->corpsRigide->getPosition();
+    Vector3D delta = posB - posA;
+
+    float distanceSq = delta.dot(delta);
+    float radiusA = std::max(a->HalfExtent.GetNorm(), 1.f);
+    float radiusB = std::max(b->HalfExtent.GetNorm(), 1.f);
+    float radiusSum = radiusA + radiusB;
+
+    if (distanceSq > radiusSum * radiusSum)
+    {
+        return;
+    }
+
+    float distance = std::sqrt(std::max(distanceSq, 1e-6f));
+    Vector3D normal = (distance > 1e-4f) ? delta.scalar(1.f / distance) : Vector3D(0.f, 1.f, 0.f);
+    float penetration = radiusSum - distance;
+
+    Vector3D contactPoint = posA + normal.scalar(radiusA - penetration * 0.5f);
+
+    collisionSystem->add(a, b, contactPoint, normal, penetration, 0.45f, collision_type::Contact);
+}
+
+void World::stepRigidBodies(std::vector<RigidBodyBox>& rigidBodies,
+                            const std::vector<Plane>& staticPlanes,
+                            float deltaTime,
+                            const AABB& worldBounds)
+{
+    m_worldBounds = worldBounds;
+    m_rigidBodies.clear();
+
+    for (auto& box : rigidBodies)
+    {
+        if (!box.primitive)
+        {
+            box.primitive = std::make_unique<Box>(box.halfExtents);
+        }
+
+        box.primitive->HalfExtent = box.halfExtents;
+        box.primitive->corpsRigide = &box.body;
+        m_rigidBodies.push_back(&box);
+    }
+
+    for (auto& entry : m_rigidBodies)
+    {
+        applyRigidBodyForces(entry->body, deltaTime);
+        entry->body.integrer(deltaTime);
+    }
+
+    // Broad puis narrow phase pour les collisions dynamique-dynamique
+    broadPhaseDetection();
+
+    // Détection Box-Plane en phase restreinte (plans statiques)
+    if (collisionSystem)
+    {
+        for (auto& entry : m_rigidBodies)
+        {
+            for (const Plane& planeTemplate : staticPlanes)
+            {
+                Plane plane = planeTemplate;
+                collisionSystem->DetectBoxPlane(entry->primitive.get(), &plane);
+            }
+        }
+
+        collisionSystem->resolveAll();
+    }
+
+    for (auto& entry : m_rigidBodies)
+    {
+        entry->body.clearAccumulators();
     }
 }
 

--- a/MoteurPhysique/src/World/World.cpp
+++ b/MoteurPhysique/src/World/World.cpp
@@ -212,7 +212,13 @@ void World::broadPhaseDetection() {
                         continue;
                 }
 
-                std::vector<Primitive*> condidates = m_octree->request(sphereBounds[primitiveA]);
+                auto boundsIt = sphereBounds.find(primitiveA);
+                if (boundsIt == sphereBounds.end())
+                {
+                        continue;
+                }
+
+                std::vector<Primitive*> condidates = m_octree->request(boundsIt->second);
 
                 for (Primitive* primitiveB : condidates) {
                         if (primitiveA < primitiveB) {
@@ -319,6 +325,7 @@ void World::stepRigidBodies(std::vector<RigidBodyBox>& rigidBodies,
     // Ajuste dynamiquement les limites de l'octree pour inclure tous les corps
     // simulés, même s'ils ont quitté le volume de base.
     AABB expandedBounds = worldBounds;
+    bool hasBodies = false;
     for (const auto& entry : m_rigidBodies)
     {
         if (!entry || !entry->primitive)
@@ -328,15 +335,25 @@ void World::stepRigidBodies(std::vector<RigidBodyBox>& rigidBodies,
 
         Vector3D center = entry->body.getPosition();
         float radius = entry->boundingRadius;
-        expandedBounds.min.x = std::min(expandedBounds.min.x, center.x - radius);
-        expandedBounds.min.y = std::min(expandedBounds.min.y, center.y - radius);
-        expandedBounds.min.z = std::min(expandedBounds.min.z, center.z - radius);
-        expandedBounds.max.x = std::max(expandedBounds.max.x, center.x + radius);
-        expandedBounds.max.y = std::max(expandedBounds.max.y, center.y + radius);
-        expandedBounds.max.z = std::max(expandedBounds.max.z, center.z + radius);
+
+        if (!hasBodies)
+        {
+            expandedBounds.min = center - Vector3D(radius, radius, radius);
+            expandedBounds.max = center + Vector3D(radius, radius, radius);
+            hasBodies = true;
+        }
+        else
+        {
+            expandedBounds.min.x = std::min(expandedBounds.min.x, center.x - radius);
+            expandedBounds.min.y = std::min(expandedBounds.min.y, center.y - radius);
+            expandedBounds.min.z = std::min(expandedBounds.min.z, center.z - radius);
+            expandedBounds.max.x = std::max(expandedBounds.max.x, center.x + radius);
+            expandedBounds.max.y = std::max(expandedBounds.max.y, center.y + radius);
+            expandedBounds.max.z = std::max(expandedBounds.max.z, center.z + radius);
+        }
     }
 
-    m_worldBounds = expandedBounds;
+    m_worldBounds = hasBodies ? expandedBounds : worldBounds;
 
     // Broad puis narrow phase pour les collisions dynamique-dynamique
     broadPhaseDetection();

--- a/MoteurPhysique/src/World/World.cpp
+++ b/MoteurPhysique/src/World/World.cpp
@@ -296,7 +296,6 @@ void World::stepRigidBodies(std::vector<RigidBodyBox>& rigidBodies,
                             float deltaTime,
                             const AABB& worldBounds)
 {
-    m_worldBounds = worldBounds;
     m_rigidBodies.clear();
 
     for (auto& box : rigidBodies)
@@ -316,6 +315,28 @@ void World::stepRigidBodies(std::vector<RigidBodyBox>& rigidBodies,
         applyRigidBodyForces(entry->body, deltaTime);
         entry->body.integrer(deltaTime);
     }
+
+    // Ajuste dynamiquement les limites de l'octree pour inclure tous les corps
+    // simulés, même s'ils ont quitté le volume de base.
+    AABB expandedBounds = worldBounds;
+    for (const auto& entry : m_rigidBodies)
+    {
+        if (!entry || !entry->primitive)
+        {
+            continue;
+        }
+
+        Vector3D center = entry->body.getPosition();
+        float radius = entry->boundingRadius;
+        expandedBounds.min.x = std::min(expandedBounds.min.x, center.x - radius);
+        expandedBounds.min.y = std::min(expandedBounds.min.y, center.y - radius);
+        expandedBounds.min.z = std::min(expandedBounds.min.z, center.z - radius);
+        expandedBounds.max.x = std::max(expandedBounds.max.x, center.x + radius);
+        expandedBounds.max.y = std::max(expandedBounds.max.y, center.y + radius);
+        expandedBounds.max.z = std::max(expandedBounds.max.z, center.z + radius);
+    }
+
+    m_worldBounds = expandedBounds;
 
     // Broad puis narrow phase pour les collisions dynamique-dynamique
     broadPhaseDetection();

--- a/MoteurPhysique/src/World/World.h
+++ b/MoteurPhysique/src/World/World.h
@@ -51,6 +51,20 @@ public:
     SystemCollisionDetection* getCollisionDetector();
 
     /**
+     * @brief Met à jour les corps rigides, reconstruit la structure de partition
+     *        et résout les collisions contre les plans fournis.
+     */
+    void stepRigidBodies(std::vector<RigidBodyBox>& rigidBodies,
+                         const std::vector<Plane>& staticPlanes,
+                         float deltaTime,
+                         const AABB& worldBounds);
+
+    /**
+     * @brief AABBs utilisées pour l'affichage du partitionnement spatial.
+     */
+    const std::vector<AABB>& getDebugOctreeNodes() const { return m_octreeDebugNodes; }
+
+    /**
      * @brief Crée et configure un pavé rigide prêt à être simulé.
      */
     RigidBodyBox createRigidBodyBox(const Vector3D& position,
@@ -82,12 +96,16 @@ private:
 	std::vector<RigidBodyBox*> m_rigidBodies;
 
 	// L'Octree, reconstruit à chaque frame
-	std::unique_ptr<Octree> m_octree;
+        std::unique_ptr<Octree> m_octree;
 
-	// Les limites de l'espace de simulation
-	AABB m_worldBounds;
+        // Noeuds utilisés pour l'affichage de la structure de partition.
+        std::vector<AABB> m_octreeDebugNodes;
 
-	// Méthodes privées pour la détection de collision
-	void broadPhaseDetection();
-	void narrowPhaseDetection(const std::vector<std::pair<Primitive*, Primitive*>>& potentialCollisions);
+        // Les limites de l'espace de simulation
+        AABB m_worldBounds;
+
+        // Méthodes privées pour la détection de collision
+        void broadPhaseDetection();
+        void narrowPhaseDetection(const std::vector<std::pair<Primitive*, Primitive*>>& potentialCollisions);
+        void detectSphereSphere(Box* a, Box* b);
 };

--- a/MoteurPhysique/src/World/WorldObject/Primitive.cpp
+++ b/MoteurPhysique/src/World/WorldObject/Primitive.cpp
@@ -1,6 +1,10 @@
 #include "Primitive.h"
 Matrix4 Primitive::GetTransformMatrix() const
 {
+    if (!corpsRigide)
+    {
+        return offset;
+    }
     return corpsRigide->getTransformMatrix() * offset;
 }
 

--- a/MoteurPhysique/src/ofApp.cpp
+++ b/MoteurPhysique/src/ofApp.cpp
@@ -600,16 +600,43 @@ void ofApp::updateRigidBodyGame(float dt)
         dropperX = ofClamp(dropperX + moveX, -rigidBodyBoundsX + 20.f, rigidBodyBoundsX - 20.f);
         dropperZ = ofClamp(dropperZ + moveZ, -rigidBodyBoundsZ + 20.f, rigidBodyBoundsZ - 20.f);
 
+        std::vector<Plane> planes;
+        Plane floorPlane;
+        floorPlane.normal = Vector3D(0.f, 1.f, 0.f);
+        floorPlane.PlaneOffset = rigidBodyFloorY;
+        planes.push_back(floorPlane);
+
+        Plane wallPosX;
+        wallPosX.normal = Vector3D(-1.f, 0.f, 0.f);
+        wallPosX.PlaneOffset = rigidBodyBoundsX;
+        planes.push_back(wallPosX);
+
+        Plane wallNegX;
+        wallNegX.normal = Vector3D(1.f, 0.f, 0.f);
+        wallNegX.PlaneOffset = rigidBodyBoundsX;
+        planes.push_back(wallNegX);
+
+        Plane wallPosZ;
+        wallPosZ.normal = Vector3D(0.f, 0.f, -1.f);
+        wallPosZ.PlaneOffset = rigidBodyBoundsZ;
+        planes.push_back(wallPosZ);
+
+        Plane wallNegZ;
+        wallNegZ.normal = Vector3D(0.f, 0.f, 1.f);
+        wallNegZ.PlaneOffset = rigidBodyBoundsZ;
+        planes.push_back(wallNegZ);
+
+        AABB worldBounds(
+                Vector3D(-rigidBodyBoundsX * 1.2f, rigidBodyFloorY - 240.f, -rigidBodyBoundsZ * 1.2f),
+                Vector3D(rigidBodyBoundsX * 1.2f, dropperSpawnHeight + 340.f, rigidBodyBoundsZ * 1.2f));
+
+        physicsWorld.stepRigidBodies(rigidBodies, planes, dt, worldBounds);
+
         for (auto& box : rigidBodies) {
                 if (box.reachedGoal || box.outOfBounds) {
                         continue;
                 }
 
-                physicsWorld.applyRigidBodyForces(box.body, dt);
-
-                box.body.integrer(dt);
-
-                applyRigidBodyBounds(box);
                 handleRigidBodyGoal(box);
 
                 Vector3D position = box.body.getPosition();
@@ -763,6 +790,19 @@ void ofApp::drawRigidBodyGame()
                 }
                 ofPopStyle();
                 ofPopMatrix();
+        }
+
+        const auto& debugNodes = physicsWorld.getDebugOctreeNodes();
+        if (!debugNodes.empty()) {
+                ofPushStyle();
+                ofNoFill();
+                ofSetColor(120, 200, 255, 110);
+                for (const auto& node : debugNodes) {
+                        Vector3D center = node.getCenter();
+                        Vector3D size = node.max - node.min;
+                        ofDrawBox(center.x, center.y, center.z, size.x, size.y, size.z);
+                }
+                ofPopStyle();
         }
 
         rigidBodyCamera.end();


### PR DESCRIPTION
## Summary
- add sphere-based broad-phase using an octree and new narrow-phase handling for box-box and box-plane contacts
- expose a rigid-body simulation step that applies forces, detects collisions, and shares octree debug nodes for rendering
- render the partitioning structure in the phase 3 scene and harden primitive ownership/transform safety

## Testing
- Not run (not available in this environment)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6934abe3e2a08320828f8ae896d449a1)