### PR TITLE
Add rigid body collision detection and octree debug scene

### DIFF
--- a/MoteurPhysique/src/MathStruct/Octree.cpp
+++ b/MoteurPhysique/src/MathStruct/Octree.cpp
@@ -159,3 +159,18 @@ bool Octree::containsEntiraly(const AABB& other) const
 {
     return Area.contains(other);
 }
+
+void Octree::collectBounds(std::vector<AABB>& outNodes) const
+{
+    outNodes.push_back(Area);
+
+    if (!bHasBeenSubdivide) {
+        return;
+    }
+
+    for (const auto& child : children) {
+        if (child) {
+            child->collectBounds(outNodes);
+        }
+    }
+}

--- a/MoteurPhysique/src/MathStruct/Octree.h
+++ b/MoteurPhysique/src/MathStruct/Octree.h
@@ -3,6 +3,9 @@
 #include "ofEvent.h"
 #include "WorldObject/Primitive.h"
 
+#include <array>
+#include <memory>
+
 class Octree
 {
 public:
@@ -13,6 +16,8 @@ public:
     bool insert(Primitive* object,const AABB& NewArea);
 
     std::vector<Primitive*> request(const AABB& otherBounds);
+
+    void collectBounds(std::vector<AABB>& outNodes) const;
 
     bool containsEntiraly(const AABB& other) const;
 private:

--- a/MoteurPhysique/src/World/RigidBodyBox.h
+++ b/MoteurPhysique/src/World/RigidBodyBox.h
@@ -13,6 +13,6 @@ struct RigidBodyBox
         float boundingRadius = 1.f;
         bool reachedGoal = false;
         bool outOfBounds = false;
-		Primitive* primitive = new Box(halfExtents);
+        Primitive* primitive = nullptr;
 };
 

--- a/MoteurPhysique/src/World/World.cpp
+++ b/MoteurPhysique/src/World/World.cpp
@@ -82,6 +82,15 @@ RigidBodyBox World::createRigidBodyBox(const Vector3D& position,
     box.reachedGoal = false;
     box.outOfBounds = false;
 
+    if (box.primitive == nullptr)
+    {
+        box.primitive = new Box(halfExtents);
+    }
+    else if (Box* primitiveBox = dynamic_cast<Box*>(box.primitive))
+    {
+        primitiveBox->HalfExtent = halfExtents;
+    }
+
     Vector3D radiusVec = halfExtents;
     box.boundingRadius = std::max(radiusVec.GetNorm(), 6.f);
 
@@ -289,15 +298,17 @@ void World::update(float deltaTime)
 
     m_collisionDetector.resolveAll();
 
-	// CorpsRigide
+        // CorpsRigide
         for (auto& bodybox : m_rigidBodies) {
                 applyRigidBodyForces(bodybox->body, deltaTime);
 
                 bodybox->body.integrer(deltaTime);
         }
 
-	broadPhaseDetection();
-	// TODO : phase restreinte et resolution
+        broadPhaseDetection();
+        if (collisionSystem) {
+                collisionSystem->resolveAll();
+        }
 
 	for (auto& bodybox : m_rigidBodies) {
 		bodybox->body.clearAccumulators();

--- a/MoteurPhysique/src/World/World.cpp
+++ b/MoteurPhysique/src/World/World.cpp
@@ -23,7 +23,7 @@ Vector3D normalizedAxis(float x, float y, float z)
 
 World::World()
 {
-	collisionSystem = std::make_unique<SystemeCollisionDetection>();
+        collisionSystem = std::make_unique<SystemeCollisionDetection>();
 }
 
 World::~World()
@@ -116,6 +116,8 @@ RigidBodyBox World::createRigidBodyBox(const Vector3D& position,
     box.body.setVelociteAngulaire(initialAngularVelocity);
     box.body.clearAccumulators();
 
+    box.primitive->corpsRigide = &box.body;
+
     return box;
 }
 
@@ -159,14 +161,33 @@ std::vector<RigidBodyBox> World::createRigidBodyGame(int boxCount,
     return boxes;
 }
 
-void World::broadPhaseDetection() {
-	// Construire l'octree
-	m_octree = std::make_unique<Octree>(m_worldBounds);
+void World::setWorldBounds(const AABB& bounds)
+{
+        m_worldBounds = bounds;
+}
 
-	// MAJ AABB et insert dans le octree
-	for (auto & body_box : m_rigidBodies) {
-		body_box->body.calculateWorldAABB(*body_box->primitive);
-		m_octree->insert(body_box->primitive, body_box->body.worldAABB);
+void World::registerRigidBody(RigidBodyBox& body)
+{
+        if (body.primitive && body.primitive->corpsRigide == nullptr) {
+                body.primitive->corpsRigide = &body.body;
+        }
+        m_rigidBodies.push_back(&body);
+}
+
+void World::clearRigidBodies()
+{
+        m_rigidBodies.clear();
+}
+
+void World::broadPhaseDetection() {
+        // Construire l'octree
+        m_octree = std::make_unique<Octree>(m_worldBounds);
+        m_octreeNodes.clear();
+
+        // MAJ AABB et insert dans le octree
+        for (auto & body_box : m_rigidBodies) {
+                body_box->body.calculateWorldAABB(*body_box->primitive);
+                m_octree->insert(body_box->primitive, body_box->body.worldAABB);
 	}
 
 	// Genere les pairs potentielles
@@ -185,10 +206,10 @@ void World::broadPhaseDetection() {
 	}
 
 
-	// À ce stade, normalement `potentialCollisions` contient toutes les paires à tester en phase restreinte.
-	narrowPhaseDetection(potentialCollisions);
-	
-	std::cout << "Collisions potentielles cette frame: " << potentialCollisions.size() << std::endl;
+        // À ce stade, normalement `potentialCollisions` contient toutes les paires à tester en phase restreinte.
+        narrowPhaseDetection(potentialCollisions);
+
+        m_octree->collectBounds(m_octreeNodes);
 
 }
 
@@ -215,6 +236,32 @@ void World::narrowPhaseDetection(const std::vector<std::pair<Primitive *, Primit
         Box* box2 = dynamic_cast<Box*>(p2);
         Plane* plane1 = dynamic_cast<Plane*>(p1);
         Plane* plane2 = dynamic_cast<Plane*>(p2);
+
+        if (box1 && box2) {
+                const AABB& a = box1->corpsRigide->worldAABB;
+                const AABB& b = box2->corpsRigide->worldAABB;
+
+                if (a.intersects(b)) {
+                        float overlapX = std::min(a.max.x - b.min.x, b.max.x - a.min.x);
+                        float overlapY = std::min(a.max.y - b.min.y, b.max.y - a.min.y);
+                        float overlapZ = std::min(a.max.z - b.min.z, b.max.z - a.min.z);
+
+                        float minOverlap = overlapX;
+                        Vector3D normal( (a.getCenter().x < b.getCenter().x) ? -1.f : 1.f, 0.f, 0.f);
+
+                        if (overlapY < minOverlap) {
+                                minOverlap = overlapY;
+                                normal = Vector3D(0.f, (a.getCenter().y < b.getCenter().y) ? -1.f : 1.f, 0.f);
+                        }
+                        if (overlapZ < minOverlap) {
+                                minOverlap = overlapZ;
+                                normal = Vector3D(0.f, 0.f, (a.getCenter().z < b.getCenter().z) ? -1.f : 1.f);
+                        }
+
+                        Vector3D contactPoint = (box1->corpsRigide->getPosition() + box2->corpsRigide->getPosition()).scalar(0.5f);
+                        collisionSystem->add(box1, box2, contactPoint, normal, minOverlap, 0.55f, collision_type::Contact);
+                }
+        }
 
         // --- Cas : Boîte vs Plan ---
         if (box1 && plane2)
@@ -243,11 +290,11 @@ void World::update(float deltaTime)
     m_collisionDetector.resolveAll();
 
 	// CorpsRigide
-	for (auto& bodybox : m_rigidBodies) {
-		applyRigidBodyForces(bodybox->body, deltaTime);
+        for (auto& bodybox : m_rigidBodies) {
+                applyRigidBodyForces(bodybox->body, deltaTime);
 
-		bodybox->body.integrer(deltaTime);
-	}
+                bodybox->body.integrer(deltaTime);
+        }
 
 	broadPhaseDetection();
 	// TODO : phase restreinte et resolution
@@ -256,4 +303,17 @@ void World::update(float deltaTime)
 		bodybox->body.clearAccumulators();
 	}
 
+}
+
+void World::detectAndResolveRigidBodyCollisions()
+{
+        broadPhaseDetection();
+        if (collisionSystem) {
+                collisionSystem->resolveAll();
+        }
+}
+
+const std::vector<AABB>& World::getOctreeNodes() const
+{
+        return m_octreeNodes;
 }

--- a/MoteurPhysique/src/World/World.cpp
+++ b/MoteurPhysique/src/World/World.cpp
@@ -186,18 +186,30 @@ void World::registerRigidBody(RigidBodyBox& body)
 void World::clearRigidBodies()
 {
         m_rigidBodies.clear();
+        m_octreeNodes.clear();
+        m_octree.reset();
 }
 
 void World::broadPhaseDetection() {
+        if (collisionSystem) {
+                collisionSystem->clear();
+        }
+
         // Construire l'octree
         m_octree = std::make_unique<Octree>(m_worldBounds);
         m_octreeNodes.clear();
+
+        // Aucun corps actif : on retourne immédiatement avec un octree vide.
+        if (m_rigidBodies.empty()) {
+                m_octree->collectBounds(m_octreeNodes);
+                return;
+        }
 
         // MAJ AABB et insert dans le octree
         for (auto & body_box : m_rigidBodies) {
                 body_box->body.calculateWorldAABB(*body_box->primitive);
                 m_octree->insert(body_box->primitive, body_box->body.worldAABB);
-	}
+        }
 
 	// Genere les pairs potentielles
 	std::vector<std::pair<Primitive*, Primitive*>> potentialCollisions;

--- a/MoteurPhysique/src/World/World.h
+++ b/MoteurPhysique/src/World/World.h
@@ -68,6 +68,13 @@ public:
                                                   float boundsX,
                                                   float boundsZ) const;
 
+    void setWorldBounds(const AABB& bounds);
+    void registerRigidBody(RigidBodyBox& body);
+    void clearRigidBodies();
+
+    void detectAndResolveRigidBodyCollisions();
+    const std::vector<AABB>& getOctreeNodes() const;
+
 private:
     std::vector<Particule*> m_particules;
 
@@ -78,8 +85,10 @@ private:
 	// Systeme de collision
 	std::unique_ptr<SystemeCollisionDetection> collisionSystem;
 	
-	// Le monde possède les corps rigides
-	std::vector<RigidBodyBox*> m_rigidBodies;
+        // Le monde possède les corps rigides
+        std::vector<RigidBodyBox*> m_rigidBodies;
+
+        std::vector<AABB> m_octreeNodes;
 
 	// L'Octree, reconstruit à chaque frame
 	std::unique_ptr<Octree> m_octree;

--- a/MoteurPhysique/src/ofApp.cpp
+++ b/MoteurPhysique/src/ofApp.cpp
@@ -544,7 +544,6 @@ void ofApp::addRigidBodyBox(RigidBodyBox&& box)
 void ofApp::performRigidBodyGameReset()
 {
         rigidBodies.clear();
-        rigidBodies.reserve(48);
         pendingRigidBodySpawns.clear();
 
         rigidBodyScore = 0;

--- a/MoteurPhysique/src/ofApp.cpp
+++ b/MoteurPhysique/src/ofApp.cpp
@@ -121,6 +121,7 @@ void ofApp::update(){
                 blob.update(dt, useVerletBlob, applyGravityBlob, applyFrictionBlob, applySpringsBlob);
                 break;
         case SceneType::Phase3Game:
+        case SceneType::OctreeDebug:
                 updateRigidBodyGame(dt);
                 break;
         }
@@ -141,6 +142,9 @@ void ofApp::draw(){
                 break;
         case SceneType::Phase3Game:
                 drawRigidBodyGame();
+                break;
+        case SceneType::OctreeDebug:
+                drawOctreeDebug();
                 break;
         }
 
@@ -209,7 +213,8 @@ void ofApp::drawHud() const
         stream << "Scènes (Tab)\n";
         stream << ((activeScene == SceneType::Phase1Projectiles) ? "[x]" : "[ ]") << " Phase 1 - Projectiles (P)\n";
         stream << ((activeScene == SceneType::Phase2Blob) ? "[x]" : "[ ]") << " Phase 2 - Blob (B)\n\n";
-        stream << ((activeScene == SceneType::Phase3Game) ? "[x]" : "[ ]") << " Phase 3 - Jeu de caisses (J)\n\n";
+        stream << ((activeScene == SceneType::Phase3Game) ? "[x]" : "[ ]") << " Phase 3 - Jeu de caisses (J)\n";
+        stream << ((activeScene == SceneType::OctreeDebug) ? "[x]" : "[ ]") << " Phase 4 - Octree (O)\n\n";
 
         if (activeScene == SceneType::Phase1Projectiles) {
                 stream << "Projectiles actifs : " << projectiles.size() << "\n";
@@ -240,6 +245,9 @@ void ofApp::drawHud() const
                 stream << "Déplacer le distributeur : Flèches ou ZQSD\n";
                 stream << "Lancer une caisse : Espace\n";
                 stream << "Réinitialiser : R\n";
+        } else if (activeScene == SceneType::OctreeDebug) {
+                stream << "Octree : " << (showOctree ? "visible" : "caché") << " (T)\n";
+                stream << "Scène basée sur le jeu de caisses\n";
         }
 
         stream << "Afficher le HUD : H\n";
@@ -293,11 +301,13 @@ void ofApp::keyPressed(int key){
         }
 
         if (key == OF_KEY_TAB) {
-                // Basculer entre les trois scènes de démonstration.
+                // Basculer entre les scènes de démonstration.
                 if (activeScene == SceneType::Phase1Projectiles) {
                         activeScene = SceneType::Phase2Blob;
                 } else if (activeScene == SceneType::Phase2Blob) {
                         activeScene = SceneType::Phase3Game;
+                } else if (activeScene == SceneType::Phase3Game) {
+                        activeScene = SceneType::OctreeDebug;
                 } else {
                         activeScene = SceneType::Phase1Projectiles;
                 }
@@ -305,7 +315,7 @@ void ofApp::keyPressed(int key){
                 if (activeScene != SceneType::Phase2Blob) {
                         clearBlobMovementKeys();
                 }
-                if (activeScene != SceneType::Phase3Game) {
+                if (activeScene != SceneType::Phase3Game && activeScene != SceneType::OctreeDebug) {
                         clearRigidBodyMovementKeys();
                 }
         }
@@ -324,6 +334,10 @@ void ofApp::keyPressed(int key){
                 clearBlobMovementKeys();
                 clearRigidBodyMovementKeys();
         }
+        if (key == 'o' || key == 'O') {
+                activeScene = SceneType::OctreeDebug;
+                clearBlobMovementKeys();
+        }
 
         if (key == 'h' || key == 'H') {
                 showHud = !showHud;
@@ -334,7 +348,7 @@ void ofApp::keyPressed(int key){
                         applyGravityPhase1 = !applyGravityPhase1;
                 } else if (activeScene == SceneType::Phase2Blob) {
                         applyGravityBlob = !applyGravityBlob;
-                } else if (activeScene == SceneType::Phase3Game) {
+                } else if (activeScene == SceneType::Phase3Game || activeScene == SceneType::OctreeDebug) {
                         applyGravityRigidBodies = !applyGravityRigidBodies;
                 }
         }
@@ -368,6 +382,12 @@ void ofApp::keyPressed(int key){
         if (key == 'c' || key == 'C') {
                 if (activeScene == SceneType::Phase2Blob) {
                         highlightCollisions = !highlightCollisions;
+                }
+        }
+
+        if (key == 't' || key == 'T') {
+                if (activeScene == SceneType::OctreeDebug) {
+                        showOctree = !showOctree;
                 }
         }
 
@@ -516,6 +536,7 @@ void ofApp::setupRigidBodyGame()
 void ofApp::addRigidBodyBox(RigidBodyBox&& box)
 {
         rigidBodies.push_back(std::move(box));
+        physicsWorld.registerRigidBody(rigidBodies.back());
         ++totalRigidBodySpawned;
 }
 
@@ -535,6 +556,11 @@ void ofApp::performRigidBodyGameReset()
         clearRigidBodyMovementKeys();
 
         goalCenter.y = rigidBodyFloorY;
+
+        physicsWorld.setWorldBounds(AABB(
+                Vector3D(-rigidBodyBoundsX - 40.f, rigidBodyFloorY - 120.f, -rigidBodyBoundsZ - 40.f),
+                Vector3D(rigidBodyBoundsX + 40.f, rigidBodyFloorY + 520.f, rigidBodyBoundsZ + 40.f)));
+        physicsWorld.clearRigidBodies();
 
         auto initialBoxes = physicsWorld.createRigidBodyGame(30, dropperSpawnHeight, rigidBodyBoundsX, rigidBodyBoundsZ);
         for (auto& box : initialBoxes) {
@@ -618,6 +644,8 @@ void ofApp::updateRigidBodyGame(float dt)
                         ++rigidBodyLost;
                 }
         }
+
+        physicsWorld.detectAndResolveRigidBodyCollisions();
 }
 
 //--------------------------------------------------------------
@@ -765,6 +793,34 @@ void ofApp::drawRigidBodyGame()
                 ofPopMatrix();
         }
 
+        rigidBodyCamera.end();
+        ofDisableDepthTest();
+}
+
+void ofApp::drawOctreeDebug()
+{
+        drawRigidBodyGame();
+
+        if (!showOctree) {
+                return;
+        }
+
+        const auto& nodes = physicsWorld.getOctreeNodes();
+        if (nodes.empty()) {
+                return;
+        }
+
+        ofEnableDepthTest();
+        rigidBodyCamera.begin();
+        ofPushStyle();
+        ofNoFill();
+        ofSetColor(90, 200, 255, 120);
+        for (const auto& node : nodes) {
+                Vector3D size = node.max - node.min;
+                Vector3D center = node.getCenter();
+                ofDrawBox(center.x, center.y, center.z, size.x, size.y, size.z);
+        }
+        ofPopStyle();
         rigidBodyCamera.end();
         ofDisableDepthTest();
 }

--- a/MoteurPhysique/src/ofApp.h
+++ b/MoteurPhysique/src/ofApp.h
@@ -32,7 +32,7 @@ class ofApp : public ofBaseApp{
                 void gotMessage(ofMessage msg);
         private:
                 /// Machine à états simple qui identifie la démonstration active.
-                enum class SceneType { Phase1Projectiles, Phase2Blob, Phase3Game };
+                enum class SceneType { Phase1Projectiles, Phase2Blob, Phase3Game, OctreeDebug };
 
                 /// Applique toutes les forces configurées aux projectiles actifs avant de les intégrer.
                 void updateProjectiles(float dt);
@@ -70,6 +70,7 @@ class ofApp : public ofBaseApp{
                 void updateRigidBodyGame(float dt);
                 /// Dessine l'aire de jeu ainsi que les corps rigides actifs.
                 void drawRigidBodyGame();
+                void drawOctreeDebug();
                 /// Fait apparaître un nouveau pavé à la position du distributeur contrôlé par le joueur.
                 void spawnRigidBodyFromDropper();
                 /// Replace la scène du jeu dans son état initial.
@@ -104,6 +105,7 @@ class ofApp : public ofBaseApp{
 
                 bool applyGravityRigidBodies = true;
                 bool drawRigidBodyWireframe = false;
+                bool showOctree = true;
 
                 int rigidBodyScore = 0;
                 int rigidBodyLost = 0;

--- a/MoteurPhysique/src/ofApp.h
+++ b/MoteurPhysique/src/ofApp.h
@@ -8,6 +8,7 @@
 #include "ofMain.h"
 #include "Projectile.h"
 
+#include <list>
 #include <map>
 #include <memory>
 #include <vector>
@@ -55,7 +56,7 @@ class ofApp : public ofBaseApp{
                 Blob blob;
                 ofRectangle blobBounds;
 
-                std::vector<RigidBodyBox> rigidBodies;
+                std::list<RigidBodyBox> rigidBodies;
                 std::vector<RigidBodyBox> pendingRigidBodySpawns;
                 ofEasyCam rigidBodyCamera;
                 bool rigidBodyResetRequested = false;


### PR DESCRIPTION
## Summary
- add broad- and narrow-phase collision handling for rigid bodies using the octree and new box-box contacts
- register rigid bodies within the physics world and expose octree bounds for debugging
- add an octree debug scene to visualize spatial partitioning alongside the crate game

## Testing
- not run (not available in this environment)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6934b099429c8320ad87e868b56368d1)