### PR TITLE
Integrate collision bounds into physics system

### DIFF
--- a/MoteurPhysique/src/SystemeCollision/SystemeCollisionDetection.cpp
+++ b/MoteurPhysique/src/SystemeCollision/SystemeCollisionDetection.cpp
@@ -25,6 +25,11 @@ void SystemeCollisionDetection::add(Primitive* p1, Primitive* p2, const Vector3D
     detectedCollisions.push_back(contact);
 }
 
+void SystemeCollisionDetection::setPlaneRestitution(float restitution)
+{
+        planeRestitution = std::max(0.f, restitution);
+}
+
 void SystemeCollisionDetection::addPlane(Primitive* p1, Primitive* p2, const Vector3D& point, const Vector3D& normal, float penetration, float restitution, collision_type type)
 {
     if (!p1 || !p2) return;
@@ -300,7 +305,7 @@ void SystemeCollisionDetection::DetectBoxPlane(Box* box, Plane* plane)
     {
         // Le point de contact est le sommet le plus profond.
         // La pénétration est la valeur absolue de la distance.
-        add(box, plane, deepestVertex, planeNormal, -minDistance, 0.5f, collision_type::Contact);
+        add(box, plane, deepestVertex, planeNormal, -minDistance, planeRestitution, collision_type::Contact);
     }
 }
 

--- a/MoteurPhysique/src/SystemeCollision/SystemeCollisionDetection.h
+++ b/MoteurPhysique/src/SystemeCollision/SystemeCollisionDetection.h
@@ -16,6 +16,8 @@ public:
     SystemeCollisionDetection() = default;
     ~SystemeCollisionDetection() = default;
 
+    void setPlaneRestitution(float restitution);
+
     void add(Primitive* p1, Primitive* p2, const Vector3D& point, const Vector3D& normal, float penetration, float restitution, collision_type type);
 
     void addPlane(Primitive* p1, Primitive* p2, const Vector3D& point, const Vector3D& normal, float penetration, float restitution, collision_type type);
@@ -34,4 +36,7 @@ public:
 
     void DetectBoxPlane(Box* box, Plane* plane);
     void DetectBoxBox(Box* boxA, Box* boxB);
+
+private:
+    float planeRestitution = 0.5f;
 };

--- a/MoteurPhysique/src/World/World.cpp
+++ b/MoteurPhysique/src/World/World.cpp
@@ -25,12 +25,10 @@ Vector3D normalizedAxis(float x, float y, float z)
 World::World()
 {
         collisionSystem = std::make_unique<SystemeCollisionDetection>();
+        setBoundaryRestitution(0.55f);
 
-        // Initialiser les limites du monde pour l'Octree.
-        float worldSize = 500.0f;
-        m_worldBounds = AABB(Vector3D(-worldSize, -worldSize, -worldSize), Vector3D(worldSize, worldSize, worldSize));
-
-        setupConfiningPlanes();
+    // Initialiser les limites du monde pour l'Octree.
+    setSimulationBounds(500.f, 500.f, -500.f, 500.f);
 }
 
 World::~World()
@@ -339,22 +337,31 @@ const std::vector<Contact>* World::getCollisionContacts() const
         return &collisionSystem->detectedCollisions;
 }
 
+void World::setSimulationBounds(float halfSizeX, float halfSizeZ, float floorY, float ceilingY)
+{
+        m_worldBounds = AABB(
+                Vector3D(-halfSizeX, floorY, -halfSizeZ),
+                Vector3D(halfSizeX, ceilingY, halfSizeZ));
+
+        setupConfiningPlanes();
+}
+
 void World::setupConfiningPlanes()
 {
         m_confiningPlanes.clear();
         m_confiningPlanes.reserve(6);
 
-        float worldSize = 500.0f;
+        Vector3D min = m_worldBounds.min;
+        Vector3D max = m_worldBounds.max;
 
         // Liste des normales et offsets pour les 6 faces de l'AABB
         std::vector<std::pair<Vector3D, float>> planeDefs = {
-                // Normal, Offset
-                {Vector3D( 1,  0,  0),  worldSize}, // Mur gauche (X < -500),  n=( 1,0,0), d= 500 =>  x+500=0
-                {Vector3D(-1,  0,  0),  worldSize}, // Mur droit  (X >  500),  n=(-1,0,0), d= 500 => -x+500=0
-                {Vector3D( 0,  1,  0),  worldSize}, // Sol        (Y < -500),  n=( 0,1,0), d= 500 =>  y+500=0
-                {Vector3D( 0, -1,  0),  worldSize}, // Plafond    (Y >  500),  n=( 0,-1,0),d= 500 => -y+500=0
-                {Vector3D( 0,  0,  1),  worldSize}, // Arrière    (Z < -500),  n=( 0,0,1), d= 500 =>  z+500=0
-                {Vector3D( 0,  0, -1),  worldSize}  // Avant      (Z >  500),  n=( 0,0,-1),d= 500 => -z+500=0
+                {Vector3D( 1,  0,  0), -min.x},
+                {Vector3D(-1,  0,  0),  max.x},
+                {Vector3D( 0,  1,  0), -min.y},
+                {Vector3D( 0, -1,  0),  max.y},
+                {Vector3D( 0,  0,  1), -min.z},
+                {Vector3D( 0,  0, -1),  max.z}
         };
 
         for (const auto& def : planeDefs)
@@ -378,4 +385,17 @@ void World::setupConfiningPlanes()
 
                 m_confiningPlanes.push_back(std::move(planeBox));
         }
+}
+
+void World::setBoundaryRestitution(float restitution)
+{
+        if (collisionSystem)
+        {
+                collisionSystem->setPlaneRestitution(restitution);
+        }
+}
+
+const AABB& World::getSimulationBounds() const
+{
+        return m_worldBounds;
 }

--- a/MoteurPhysique/src/World/World.h
+++ b/MoteurPhysique/src/World/World.h
@@ -64,10 +64,19 @@ public:
     /**
      * @brief Génère une collection de pavés rigides aléatoires pour initialiser la scène du jeu.
      */
-    std::vector<RigidBodyBox> createRigidBodyGame(int boxCount,
+        std::vector<RigidBodyBox> createRigidBodyGame(int boxCount,
                                                   float dropperSpawnHeight,
                                                   float boundsX,
                                                   float boundsZ) const;
+
+        /**
+         * @brief Définit les limites utilisées pour l'octree et les plans de confinement.
+         */
+        void setSimulationBounds(float halfSizeX, float halfSizeZ, float floorY, float ceilingY);
+
+        void setBoundaryRestitution(float restitution);
+
+        const AABB& getSimulationBounds() const;
 
         void drawOctree() const;
         const std::vector<Contact>* getCollisionContacts() const;

--- a/MoteurPhysique/src/ofApp.cpp
+++ b/MoteurPhysique/src/ofApp.cpp
@@ -518,6 +518,12 @@ void ofApp::setupRigidBodyGame()
         rigidBodyCamera.lookAt(glm::vec3(0.f, rigidBodyFloorY + 80.f, 0.f));
         rigidBodyCamera.setAutoDistance(false);
 
+        // Les limites de la simulation doivent correspondre à l'aire de jeu visible
+        // pour que les corps rigides ne puissent pas s'échapper dans le vide.
+        float ceilingY = dropperSpawnHeight + 180.f;
+        physicsWorld.setSimulationBounds(rigidBodyBoundsX, rigidBodyBoundsZ, rigidBodyFloorY, ceilingY);
+        physicsWorld.setBoundaryRestitution(rigidBodyBounce);
+
         performRigidBodyGameReset();
 }
 
@@ -608,6 +614,11 @@ void ofApp::updateRigidBodyGame(float dt)
 
         physicsWorld.update(dt, rigidBodies);
 
+        for (auto& box : rigidBodies) {
+                applyRigidBodyBounds(box);
+                handleRigidBodyGoal(box);
+        }
+
 }
 
 
@@ -694,6 +705,56 @@ void ofApp::drawRigidBodyGame()
 
         rigidBodyCamera.end();
         ofDisableDepthTest();
+}
+
+//--------------------------------------------------------------
+void ofApp::applyRigidBodyBounds(RigidBodyBox& box)
+{
+        if (box.isStaticPlatform || box.outOfBounds || box.reachedGoal) {
+                return;
+        }
+
+        Vector3D position = box.body.getPosition();
+
+        const AABB& bounds = physicsWorld.getSimulationBounds();
+        float verticalMargin = 120.f;
+
+        bool outside = position.x < (bounds.min.x - box.halfExtents.x)
+                        || position.x > (bounds.max.x + box.halfExtents.x)
+                        || position.z < (bounds.min.z - box.halfExtents.z)
+                        || position.z > (bounds.max.z + box.halfExtents.z)
+                        || position.y < (bounds.min.y - verticalMargin)
+                        || position.y > (bounds.max.y + verticalMargin);
+
+        if (outside) {
+                box.outOfBounds = true;
+                ++rigidBodyLost;
+                box.body.setVelocite(Vector3D());
+                box.body.setVelociteAngulaire(Vector3D());
+        }
+}
+
+//--------------------------------------------------------------
+void ofApp::handleRigidBodyGoal(RigidBodyBox& box)
+{
+        if (box.isStaticPlatform || box.outOfBounds || box.reachedGoal) {
+                return;
+        }
+
+        Vector3D position = box.body.getPosition();
+        float halfGoal = goalSize * 0.5f;
+
+        bool withinX = std::abs(position.x - goalCenter.x) <= halfGoal - box.halfExtents.x;
+        bool withinZ = std::abs(position.z - goalCenter.z) <= halfGoal - box.halfExtents.z;
+        bool touchingFloor = position.y <= rigidBodyFloorY + box.halfExtents.y + 2.f;
+
+        if (withinX && withinZ && touchingFloor) {
+                box.reachedGoal = true;
+                ++rigidBodyScore;
+
+                box.body.setVelocite(Vector3D());
+                box.body.setVelociteAngulaire(Vector3D());
+        }
 }
 
 //--------------------------------------------------------------

--- a/MoteurPhysique/src/ofApp.h
+++ b/MoteurPhysique/src/ofApp.h
@@ -88,7 +88,6 @@ private:
         float rigidBodyBoundsX = 320.f;
         float rigidBodyBoundsZ = 320.f;
         float rigidBodyBounce = 0.55f;
-        float rigidBodyFloorFriction = 0.8f;
         Vector3D goalCenter = Vector3D(0.f, -220.f, -80.f);
         float goalSize = 160.f;
 


### PR DESCRIPTION
## Summary
- expose configurable restitution for plane contacts and pass world bounds to callers
- align phase 3 setup with collision-based boundaries instead of manual clamping
- track out-of-bounds crates using simulation AABB rather than mutating their state directly

## Testing
- not run (not available)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6935fdb80c488320b9088d2fbe48190e)